### PR TITLE
Remove override of Array.from

### DIFF
--- a/vendor/assets/javascripts/prototype.js
+++ b/vendor/assets/javascripts/prototype.js
@@ -1078,7 +1078,7 @@ function $w(string) {
   return string ? string.split(/\s+/) : [];
 }
 
-Array.from = $A;
+// Array.from = $A;
 
 
 (function() {


### PR DESCRIPTION
- Fix Google Maps JS error: This site overrides Array.from() with an implementation that doesn't support iterables, which could cause Google Maps JavaScript API v3 to not work correctly.